### PR TITLE
[CMWP-648] Make PHP base images public

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 These images extend the [offical php-fpm images](https://github.com/docker-library/php/blob/76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68/7.1/fpm/alpine/Dockerfile) with PHP extensions in use on the WP Engine Platform. They are based on Alpine Linux.
 
-By default, these images will run php-fpm and listen for FastCGI connections on port 9000.
-
 Updates & Prebuilt Images
 ---
 
-These images are configured as Automated builds on [Docker Hub](https://hub.docker.com/r/wpengine/php/).  New automated builds are triggered by updates to the official PHP images.
+These images are configured as Automated builds on [Docker Hub](https://hub.docker.com/r/wpengine/php/).  New automated builds are triggered by updates to the official PHP repo.
 
 Running
 ---
+
+By default, this will run php-fpm and listen for FastCGI connections on port 9000.
 
     docker run -d -p 9000:9000 wpengine/php:7.0
 


### PR DESCRIPTION
Our PHP base images are up on [Docker hub](https://hub.docker.com/r/wpengine/php/) with all of the non-secret sauce bits.  Eventually, we would like to use these for customer development environments.

This is just a readme file update, but I'm looking for feedback on anything else that we should do before making the repo public.

I'm planning on using the MIT license and enabling GitHub issues for the repo.
