### PR TITLE
[CMWP-652] Added NewRelic php extension

### DIFF
--- a/Dockerfile.php5.6
+++ b/Dockerfile.php5.6
@@ -87,8 +87,8 @@ RUN set -ex; \
 		curl -sS https://download.newrelic.com/php_agent/release/ \
 			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
 	)"; \
-    curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
-    tar -xf nr.tar.gz; \
+	curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+	tar -xf nr.tar.gz; \
 	cp $NR_VERSION/agent/x64/newrelic-20131226.so /usr/local/lib/php/extensions/no-debug-non-zts-20131226/newrelic.so; \
 	mkdir -p /var/log/newrelic; \
 	rm -rf newrelic-php5* nr.tar.gz; \

--- a/Dockerfile.php5.6
+++ b/Dockerfile.php5.6
@@ -84,10 +84,10 @@ RUN set -ex; \
 RUN set -ex; \
 	\
 	NR_VERSION="$( \
-		curl -sS https://download.newrelic.com/php_agent/release/ \
+		curl --connect-timeout 10 -sS https://download.newrelic.com/php_agent/release/ \
 			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
 	)"; \
-	curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+	curl --connect-timeout 10 -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
 	tar -xf nr.tar.gz; \
 	cp $NR_VERSION/agent/x64/newrelic-20131226.so /usr/local/lib/php/extensions/no-debug-non-zts-20131226/newrelic.so; \
 	mkdir -p /var/log/newrelic; \

--- a/Dockerfile.php5.6
+++ b/Dockerfile.php5.6
@@ -78,4 +78,20 @@ RUN set -ex; \
 			| sort -u \
 	)"; \
 	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
-	apk del .build-deps
+	apk del .build-deps; \
+	rm -rf /tmp/pear/;
+
+RUN set -ex; \
+	\
+	NR_VERSION="$( \
+		curl -sS https://download.newrelic.com/php_agent/release/ \
+			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
+	)"; \
+    curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+    tar -xf nr.tar.gz; \
+	cp $NR_VERSION/agent/x64/newrelic-20131226.so /usr/local/lib/php/extensions/no-debug-non-zts-20131226/newrelic.so; \
+	mkdir -p /var/log/newrelic; \
+	rm -rf newrelic-php5* nr.tar.gz; \
+	{ \
+		echo "extension=newrelic.so"; \
+	} > /usr/local/etc/php/conf.d/docker-php-ext-newrelic.ini

--- a/Dockerfile.php7.0
+++ b/Dockerfile.php7.0
@@ -83,10 +83,10 @@ RUN set -ex; \
 RUN set -ex; \
 	\
 	NR_VERSION="$( \
-		curl -sS https://download.newrelic.com/php_agent/release/ \
+		curl --connect-timeout 10 -sS https://download.newrelic.com/php_agent/release/ \
 			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
 	)"; \
-	curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+	curl --connect-timeout 10 -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
 	tar -xf nr.tar.gz; \
 	cp $NR_VERSION/agent/x64/newrelic-20151012.so /usr/local/lib/php/extensions/no-debug-non-zts-20151012/newrelic.so; \
 	mkdir -p /var/log/newrelic; \

--- a/Dockerfile.php7.0
+++ b/Dockerfile.php7.0
@@ -86,8 +86,8 @@ RUN set -ex; \
 		curl -sS https://download.newrelic.com/php_agent/release/ \
 			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
 	)"; \
-    curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
-    tar -xf nr.tar.gz; \
+	curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+	tar -xf nr.tar.gz; \
 	cp $NR_VERSION/agent/x64/newrelic-20151012.so /usr/local/lib/php/extensions/no-debug-non-zts-20151012/newrelic.so; \
 	mkdir -p /var/log/newrelic; \
 	rm -rf newrelic-php5* nr.tar.gz; \

--- a/Dockerfile.php7.0
+++ b/Dockerfile.php7.0
@@ -77,4 +77,20 @@ RUN set -ex; \
 			| sort -u \
 	)"; \
 	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
-	apk del .build-deps
+	apk del .build-deps; \
+	rm -rf /tmp/pear/;
+
+RUN set -ex; \
+	\
+	NR_VERSION="$( \
+		curl -sS https://download.newrelic.com/php_agent/release/ \
+			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
+	)"; \
+    curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+    tar -xf nr.tar.gz; \
+	cp $NR_VERSION/agent/x64/newrelic-20151012.so /usr/local/lib/php/extensions/no-debug-non-zts-20151012/newrelic.so; \
+	mkdir -p /var/log/newrelic; \
+	rm -rf newrelic-php5* nr.tar.gz; \
+	{ \
+		echo "extension=newrelic.so"; \
+	} > /usr/local/etc/php/conf.d/docker-php-ext-newrelic.ini

--- a/Dockerfile.php7.1
+++ b/Dockerfile.php7.1
@@ -77,4 +77,20 @@ RUN set -ex; \
 			| sort -u \
 	)"; \
 	apk add --virtual .wordpress-phpexts-rundeps $runDeps; \
-	apk del .build-deps
+	apk del .build-deps; \
+	rm -rf /tmp/pear/;
+
+RUN set -ex; \
+	\
+	NR_VERSION="$( \
+		curl -sS https://download.newrelic.com/php_agent/release/ \
+			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
+	)"; \
+    curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+    tar -xf nr.tar.gz; \
+	cp $NR_VERSION/agent/x64/newrelic-20160303.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/newrelic.so; \
+	mkdir -p /var/log/newrelic; \
+	rm -rf newrelic-php5* nr.tar.gz; \
+	{ \
+		echo "extension=newrelic.so"; \
+	} > /usr/local/etc/php/conf.d/docker-php-ext-newrelic.ini

--- a/Dockerfile.php7.1
+++ b/Dockerfile.php7.1
@@ -86,8 +86,8 @@ RUN set -ex; \
 		curl -sS https://download.newrelic.com/php_agent/release/ \
 			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
 	)"; \
-    curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
-    tar -xf nr.tar.gz; \
+	curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+	tar -xf nr.tar.gz; \
 	cp $NR_VERSION/agent/x64/newrelic-20160303.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/newrelic.so; \
 	mkdir -p /var/log/newrelic; \
 	rm -rf newrelic-php5* nr.tar.gz; \

--- a/Dockerfile.php7.1
+++ b/Dockerfile.php7.1
@@ -83,10 +83,10 @@ RUN set -ex; \
 RUN set -ex; \
 	\
 	NR_VERSION="$( \
-		curl -sS https://download.newrelic.com/php_agent/release/ \
+		curl --connect-timeout 10 -sS https://download.newrelic.com/php_agent/release/ \
 			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
 	)"; \
-	curl -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+	curl --connect-timeout 10 -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
 	tar -xf nr.tar.gz; \
 	cp $NR_VERSION/agent/x64/newrelic-20160303.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/newrelic.so; \
 	mkdir -p /var/log/newrelic; \

--- a/README.md
+++ b/README.md
@@ -2,21 +2,29 @@
 
 These images extend the [offical php-fpm images](https://github.com/docker-library/php/blob/76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68/7.1/fpm/alpine/Dockerfile) with PHP extensions in use on the WP Engine Platform. They are based on Alpine Linux.
 
-Updates & Prebuilt Images
----
+# Updates & Prebuilt Images
 
 These images are configured as Automated builds on [Docker Hub](https://hub.docker.com/r/wpengine/php/).  New automated builds are triggered by updates to the official PHP repo.
 
-Running
----
+# Running
 
 By default, this will run php-fpm and listen for FastCGI connections on port 9000.
 
     docker run -d -p 9000:9000 wpengine/php:7.0
 
-Building
----
+# Building
 
     docker build -t wpengine/php:7.1 -f Dockerfile.php7.1 .
     docker build -t wpengine/php:7.0 -f Dockerfile.php7.0 .
     docker build -t wpengine/php:5.6 -f Dockerfile.php5.6 .
+
+# New Relic
+
+As part of this container we install latest version of the New Relic php agent. The New Relic daemon should be run in a seperate container and the daemon socket should be mounted on /tmp/.newrelic.sock.  The socket location can be changed by setting newrelic.daemon.port.
+
+```
+RUN { \
+		echo "extension=newrelic.so"; \
+		echo "newrelic.daemon.port=/var/tmp/newrelic.sock"; \
+	} > /usr/local/etc/php/conf.d/docker-php-ext-newrelic.ini
+```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ By default, this will run php-fpm and listen for FastCGI connections on port 900
 
 # New Relic
 
-As part of this container we install latest version of the New Relic php agent. The New Relic daemon should be run in a seperate container and the daemon socket should be mounted on /tmp/.newrelic.sock.  The socket location can be changed by setting newrelic.daemon.port.
+As part of this container we install latest version of the New Relic php agent. The New Relic daemon should be run in a separate container and the daemon socket should be mounted on /tmp/.newrelic.sock.  The socket location can be changed by setting newrelic.daemon.port.
 
 ```
 RUN { \


### PR DESCRIPTION
Added NewRelic PHP extension to the public PHP base images.  We check for new versions of the agent each time we build.  This means we can't verify the sha1 but we get updates without tracking manually.

Agent configuration can be added when building from the base.  The NewRelic daemon should be run in a separate container with the socket mounted or a port exposed.