### PR TITLE
[CMWP-1444] New debian-based images

### DIFF
--- a/Dockerfile.php5.6.debian
+++ b/Dockerfile.php5.6.debian
@@ -119,6 +119,7 @@ RUN set -ex ; \
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ /usr/local/lib/php/extensions/no-debug-non-zts-20131226/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+COPY --from=builder /usr/sbin/sendmail /usr/sbin/sendmail
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php5.6.debian
+++ b/Dockerfile.php5.6.debian
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:5.6-fpm
 
 RUN set -ex; \
 	\
@@ -9,9 +9,8 @@ RUN set -ex; \
 		libbsd-dev \
 		libbz2-dev \
 		libc-client2007e-dev \
-		libc-dev \
+		libc6-dev \
 		libcurl3 \
-		libcurl3-dev \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libedit2 \
@@ -19,28 +18,30 @@ RUN set -ex; \
 		libjpeg-dev \
 		libkrb5-dev \
 		libldap2-dev \
+		libldb-dev \
 		libmagick++-dev \
 		libmagickwand-dev \
 		libmcrypt-dev \
 		libmemcached-dev \
 		libpcre3-dev \
 		libpng-dev \
+		libpng12-dev \
 		libsqlite3-0 \
 		libsqlite3-dev \
+		libssh-dev \
 		libssh2-1-dev \
 		libssl-dev \
 		libtinfo-dev \
 		libtool \
 		libxml2 \
 		libxml2-dev \
+		libxslt-dev \
 		libxslt1-dev \
 		sendmail \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
+	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
 	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
-	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
 	docker-php-ext-install \
 		bcmath \	
 		bz2 \
@@ -53,6 +54,7 @@ RUN set -ex; \
 		intl \
 		ldap \
 		mcrypt \
+		mysql \
 		mysqli \
 		opcache \
 		pdo_mysql \
@@ -67,50 +69,40 @@ RUN set -ex; \
 		xsl \ 
 		zip \
 	; \
-
 	pecl install \
 		igbinary-2.0.1 \
 		imagick-3.4.3 \
-		memcached-3.0.3 \
-		msgpack-2.0.2 \
+		memcached-2.2.0 \
+		msgpack-0.5.7 \
 		redis-3.1.3 \
-		uopz-5.0.2 \
+		runkit-1.0.4 \
 	; \
-	echo "\n" | pecl install ssh2-1.1.2; \
+	echo "\n" | pecl install ssh2-0.13; \
 	docker-php-ext-enable --ini-name pecl.ini \
 		igbinary \
 		imagick \
 		memcached \
 		msgpack \
 		redis \
+		runkit \
 		ssh2 \
-		uopz \
 	; \
+	curl --connect-timeout 10 -o ioncube.tar.gz -kfSL "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"; \
+	tar -zxvf ioncube.tar.gz; \
+	cp ioncube/ioncube_loader_lin_5.6.so /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ioncube.so; \
+	rm -Rf ioncube*; \
+	NR_VERSION="$( curl --connect-timeout 10 -skS https://download.newrelic.com/php_agent/release/ | sed -n 's/.*>\(.*linux\).tar.gz<.*/\1/p')"; \
+	curl --connect-timeout 10 -o nr.tar.gz -kfSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+	tar -xf nr.tar.gz; \
+	cp $NR_VERSION/agent/x64/newrelic-20131226.so /usr/local/lib/php/extensions/no-debug-non-zts-20131226/newrelic.so; \
+	rm -rf newrelic-php5* nr.tar.gz; \
+	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini; \
+	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/10-newrelic.ini; \
+	echo "runkit.internal_override=1" > /usr/local/etc/php/conf.d/10-runkit.ini; \
 	rm -rf /tmp/pear/; \
 	rm -rf /usr/share/doc /usr/share/man /usr/share/perl; \
 	rm -rf /usr/lib/gcc /usr/lib/python2.7; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
-
-RUN set -ex; \
-	\
-	NR_VERSION="$( \
-		curl --connect-timeout 10 -skS https://download.newrelic.com/php_agent/release/ \
-			| sed -n 's/.*>\(.*linux\).tar.gz<.*/\1/p' \
-	)"; \
-	curl --connect-timeout 10 -o nr.tar.gz -fkSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
-	tar -xf nr.tar.gz; \
-	cp $NR_VERSION/agent/x64/newrelic-20160303.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/newrelic.so; \
-	mkdir -p /var/log/newrelic; \
-	rm -rf newrelic-php5* nr.tar.gz; \
-	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/docker-php-ext-newrelic.ini;
-
-RUN set -ex ; \
-	\
-	curl --connect-timeout 10 -o ioncube.tar.gz -fkSL "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"; \
-	tar -zxvf ioncube.tar.gz; \
-	cp ioncube/ioncube_loader_lin_7.1.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/ioncube.so; \
-	rm -Rf ioncube*; \
-	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini;
 
 COPY php.ini /usr/local/etc/php/conf.d/php.ini

--- a/Dockerfile.php5.6.debian
+++ b/Dockerfile.php5.6.debian
@@ -1,4 +1,4 @@
-FROM php:5.6-fpm
+FROM php:5.6-fpm as builder
 
 RUN set -ex; \
 	\
@@ -98,11 +98,29 @@ RUN set -ex; \
 	rm -rf newrelic-php5* nr.tar.gz; \
 	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini; \
 	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/10-newrelic.ini; \
-	echo "runkit.internal_override=1" > /usr/local/etc/php/conf.d/10-runkit.ini; \
-	rm -rf /tmp/pear/; \
-	rm -rf /usr/share/doc /usr/share/man /usr/share/perl; \
-	rm -rf /usr/lib/gcc /usr/lib/python2.7; \
+	echo "runkit.internal_override=1" > /usr/local/etc/php/conf.d/10-runkit.ini;
+
+COPY php.ini /usr/local/etc/php/conf.d/php.ini
+
+# Now that all the modules are built/downloaded, use the original php:5.6-fpm image and
+# install only the runtime dependencies with the new modules and config files.
+FROM php:5.6-fpm
+
+WORKDIR /
+
+RUN set -ex ; \
+	\
+	apt-get update && apt-get install -y --no-install-recommends \
+        libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
+		libmemcached11 libmemcachedutil2 libc-client2007e; \
+	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
-COPY php.ini /usr/local/etc/php/conf.d/php.ini
+COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ /usr/local/lib/php/extensions/no-debug-non-zts-20131226/
+COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+# Some minimal config for php-fpm
+COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
+
+EXPOSE 9000
+CMD ["php-fpm"]

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -1,4 +1,4 @@
-FROM php:7.0-fpm
+FROM php:7.0-fpm as builder
 
 RUN set -ex; \
 	\
@@ -103,7 +103,7 @@ RUN set -ex; \
 	cp $NR_VERSION/agent/x64/newrelic-20151012.so /usr/local/lib/php/extensions/no-debug-non-zts-20151012/newrelic.so; \
 	mkdir -p /var/log/newrelic; \
 	rm -rf newrelic-php5* nr.tar.gz; \
-	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/docker-php-ext-newrelic.ini;
+	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/newrelic.ini;
 
 RUN set -ex ; \
 	\
@@ -114,3 +114,25 @@ RUN set -ex ; \
 	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini;
 
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
+
+FROM php:7.0-fpm
+
+ENV PHP_VERSION=7.0.22
+
+WORKDIR /
+
+RUN set -ex ; \
+	\
+	apt-get update && apt-get install -y --no-install-recommends \
+        libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
+		libmemcached11 libmemcachedutil2 libc-client2007e; \
+	cd /usr/local/etc/php; \
+	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
+
+COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20151012/ /usr/local/lib/php/extensions/no-debug-non-zts-20151012/
+COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+# Some minimal config for php-fpm
+COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
+
+EXPOSE 9000
+CMD ["php-fpm"]

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -85,12 +85,7 @@ RUN set -ex; \
 		redis \
 		ssh2 \
 		uopz \
-	; \
-	rm -rf /tmp/pear/; \
-	rm -rf /usr/share/doc /usr/share/man /usr/share/perl; \
-	rm -rf /usr/lib/gcc /usr/lib/python2.7; \
-	cd /usr/local/etc/php; \
-	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
+	;
 
 RUN set -ex; \
 	\
@@ -115,9 +110,9 @@ RUN set -ex ; \
 
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
 
+# Now that all the modules are built/downloaded, use the original php:7.0-fpm image and
+# install only the runtime dependencies with the new modules and config files.
 FROM php:7.0-fpm
-
-ENV PHP_VERSION=7.0.22
 
 WORKDIR /
 
@@ -126,6 +121,7 @@ RUN set -ex ; \
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
 		libmemcached11 libmemcachedutil2 libc-client2007e; \
+	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:7.0-fpm
 
 RUN set -ex; \
 	\
@@ -100,7 +100,7 @@ RUN set -ex; \
 	)"; \
 	curl --connect-timeout 10 -o nr.tar.gz -fkSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
 	tar -xf nr.tar.gz; \
-	cp $NR_VERSION/agent/x64/newrelic-20160303.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/newrelic.so; \
+	cp $NR_VERSION/agent/x64/newrelic-20151012.so /usr/local/lib/php/extensions/no-debug-non-zts-20151012/newrelic.so; \
 	mkdir -p /var/log/newrelic; \
 	rm -rf newrelic-php5* nr.tar.gz; \
 	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/docker-php-ext-newrelic.ini;
@@ -109,7 +109,7 @@ RUN set -ex ; \
 	\
 	curl --connect-timeout 10 -o ioncube.tar.gz -fkSL "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"; \
 	tar -zxvf ioncube.tar.gz; \
-	cp ioncube/ioncube_loader_lin_7.1.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/ioncube.so; \
+	cp ioncube/ioncube_loader_lin_7.0.so /usr/local/lib/php/extensions/no-debug-non-zts-20151012/ioncube.so; \
 	rm -Rf ioncube*; \
 	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini;
 

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -127,6 +127,7 @@ RUN set -ex ; \
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20151012/ /usr/local/lib/php/extensions/no-debug-non-zts-20151012/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+COPY --from=builder /usr/sbin/sendmail /usr/sbin/sendmail
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php7.1.debian
+++ b/Dockerfile.php7.1.debian
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:7.1-fpm as builder
 
 RUN set -ex; \
 	\
@@ -85,12 +85,7 @@ RUN set -ex; \
 		redis \
 		ssh2 \
 		uopz \
-	; \
-	rm -rf /tmp/pear/; \
-	rm -rf /usr/share/doc /usr/share/man /usr/share/perl; \
-	rm -rf /usr/lib/gcc /usr/lib/python2.7; \
-	cd /usr/local/etc/php; \
-	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
+	;
 
 RUN set -ex; \
 	\
@@ -103,7 +98,7 @@ RUN set -ex; \
 	cp $NR_VERSION/agent/x64/newrelic-20160303.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/newrelic.so; \
 	mkdir -p /var/log/newrelic; \
 	rm -rf newrelic-php5* nr.tar.gz; \
-	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/docker-php-ext-newrelic.ini;
+	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/newrelic.ini;
 
 RUN set -ex ; \
 	\
@@ -114,3 +109,26 @@ RUN set -ex ; \
 	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini;
 
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
+
+# Now that all the modules are built/downloaded, use the original php:7.1-fpm image and
+# install only the runtime dependencies with the new modules and config files.
+FROM php:7.1-fpm
+
+WORKDIR /
+
+RUN set -ex ; \
+	\
+	apt-get update && apt-get install -y --no-install-recommends \
+        libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
+		libmemcached11 libmemcachedutil2 libc-client2007e; \
+	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
+	cd /usr/local/etc/php; \
+	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
+
+COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20160303/ /usr/local/lib/php/extensions/no-debug-non-zts-20160303/
+COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+# Some minimal config for php-fpm
+COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
+
+EXPOSE 9000
+CMD ["php-fpm"]

--- a/Dockerfile.php7.1.debian
+++ b/Dockerfile.php7.1.debian
@@ -127,6 +127,7 @@ RUN set -ex ; \
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20160303/ /usr/local/lib/php/extensions/no-debug-non-zts-20160303/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+COPY --from=builder /usr/sbin/sendmail /usr/sbin/sendmail
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php7.1.debian
+++ b/Dockerfile.php7.1.debian
@@ -1,0 +1,108 @@
+FROM php:7.1-fpm
+
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
+		autoconf \
+		build-essential \
+		libbsd-dev \
+		libbz2-dev \
+		libbz2-dev \
+		libc-client2007e-dev \
+		libc-client2007e-dev \
+		libc-dev \
+		libcurl3 \
+		libcurl3-dev \
+		libcurl4-openssl-dev \
+		libedit-dev \
+		libedit2 \
+		libicu-dev \
+		libjpeg-dev \
+		libjpeg-dev \
+		libkrb5-dev \
+		libkrb5-dev \
+		libldap2-dev \
+		libldap2-dev \
+		libmagick++-dev \
+		libmagickwand-dev \
+		libmcrypt-dev \
+		libmemcached-dev \
+		libpcre3-dev \
+		libpng-dev \
+		libpng-dev \
+		libsqlite3-0 \
+		libsqlite3-dev \
+		libssh2-1-dev \
+		libssl-dev \
+		libtinfo-dev \
+		libtool \
+		libxml2 \
+		libxml2-dev \
+		libxslt1-dev \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
+	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
+	docker-php-ext-install \
+		bcmath \	
+		bz2 \
+		calendar \
+		dba \
+		exif \
+		gd \
+		gettext \
+		imap \
+		intl \
+		ldap \
+		mcrypt \
+		mysqli \
+		opcache \
+		pdo_mysql \
+		shmop \
+		soap \
+		sockets \
+		sysvmsg \
+		sysvsem \
+		sysvshm \
+		wddx \
+		xmlrpc \
+		xsl \ 
+		zip \
+	; \
+	pecl install \
+		igbinary \
+		imagick \
+		memcached \
+		msgpack \
+		redis \
+	; \
+	echo "\n" | pecl install ssh2-1.0; \
+	docker-php-ext-enable --ini-name pecl.ini \
+		igbinary \
+		imagick \
+		memcached \
+		msgpack \
+		redis \
+		ssh2 \
+	; \
+	rm -rf /tmp/pear/;
+
+RUN set -ex; \
+	\
+	NR_VERSION="$( \
+		curl --connect-timeout 10 -sS https://download.newrelic.com/php_agent/release/ \
+			| sed -n 's/.*>\(.*linux-musl\).tar.gz<.*/\1/p' \
+	)"; \
+	curl --connect-timeout 10 -o nr.tar.gz -fSL "https://download.newrelic.com/php_agent/release/$NR_VERSION.tar.gz"; \
+	tar -xf nr.tar.gz; \
+	cp $NR_VERSION/agent/x64/newrelic-20160303.so /usr/local/lib/php/extensions/no-debug-non-zts-20160303/newrelic.so; \
+	mkdir -p /var/log/newrelic; \
+	rm -rf newrelic-php5* nr.tar.gz; \
+	{ \
+		echo "extension=newrelic.so"; \
+	} > /usr/local/etc/php/conf.d/docker-php-ext-newrelic.ini
+
+COPY php.ini /usr/local/etc/php/conf.d/php.ini


### PR DESCRIPTION
Based on the public `php:*.*-fpm` images instead of building from source.

For the debian images, the final stage of the multistage build is based on the public `php:*.*-fpm` images and adds only our extra modules/extensions and their corresponding config files.