### PR TITLE
[CMWP-1546] Install sendmail in final image

### DIFF
--- a/Dockerfile.php5.6.debian
+++ b/Dockerfile.php5.6.debian
@@ -37,7 +37,6 @@ RUN set -ex; \
 		libxml2-dev \
 		libxslt-dev \
 		libxslt1-dev \
-		sendmail \
 	; \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
@@ -100,6 +99,11 @@ RUN set -ex; \
 	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/10-newrelic.ini; \
 	echo "runkit.internal_override=1" > /usr/local/etc/php/conf.d/10-runkit.ini;
 
+RUN set -ex; \
+	\
+	curl --connect-timeout 10 -o /busybox_SENDMAIL -fkSL "https://busybox.net/downloads/binaries/1.27.1-i686/busybox_SENDMAIL"; \
+	chmod 755 /busybox_SENDMAIL;
+
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
 
 # Now that all the modules are built/downloaded, use the original php:5.6-fpm image and
@@ -112,13 +116,14 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e sendmail; \
+		libmemcached11 libmemcachedutil2 libc-client2007e; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ /usr/local/lib/php/extensions/no-debug-non-zts-20131226/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+COPY --from=builder /busybox_SENDMAIL /usr/sbin/sendmail
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php5.6.debian
+++ b/Dockerfile.php5.6.debian
@@ -112,14 +112,13 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e; \
+		libmemcached11 libmemcachedutil2 libc-client2007e sendmail; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ /usr/local/lib/php/extensions/no-debug-non-zts-20131226/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
-COPY --from=builder /usr/sbin/sendmail /usr/sbin/sendmail
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php5.6.debian
+++ b/Dockerfile.php5.6.debian
@@ -99,11 +99,6 @@ RUN set -ex; \
 	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/10-newrelic.ini; \
 	echo "runkit.internal_override=1" > /usr/local/etc/php/conf.d/10-runkit.ini;
 
-RUN set -ex; \
-	\
-	curl --connect-timeout 10 -o /busybox_SENDMAIL -fkSL "https://busybox.net/downloads/binaries/1.27.1-i686/busybox_SENDMAIL"; \
-	chmod 755 /busybox_SENDMAIL;
-
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
 
 # Now that all the modules are built/downloaded, use the original php:5.6-fpm image and
@@ -116,14 +111,14 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e; \
+		libmemcached11 libmemcachedutil2 libc-client2007e sendmail; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20131226/ /usr/local/lib/php/extensions/no-debug-non-zts-20131226/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
-COPY --from=builder /busybox_SENDMAIL /usr/sbin/sendmail
+
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -107,12 +107,6 @@ RUN set -ex; \
 	rm -Rf ioncube*; \
 	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini;
 
-RUN set -ex; \
-	\
-	curl --connect-timeout 10 -o /busybox_SENDMAIL -fkSL "https://busybox.net/downloads/binaries/1.27.1-i686/busybox_SENDMAIL"; \
-	chmod 755 /busybox_SENDMAIL;
-
-
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
 
 # Now that all the modules are built/downloaded, use the original php:7.0-fpm image and
@@ -125,14 +119,13 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e; \
+		libmemcached11 libmemcachedutil2 libc-client2007e sendmail; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20151012/ /usr/local/lib/php/extensions/no-debug-non-zts-20151012/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
-COPY --from=builder /busybox_SENDMAIL /usr/sbin/sendmail
 
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -34,7 +34,6 @@ RUN set -ex; \
 		libxml2 \
 		libxml2-dev \
 		libxslt1-dev \
-		sendmail \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
@@ -100,13 +99,19 @@ RUN set -ex; \
 	rm -rf newrelic-php5* nr.tar.gz; \
 	echo "extension=newrelic.so" > /usr/local/etc/php/conf.d/newrelic.ini;
 
-RUN set -ex ; \
+RUN set -ex; \
 	\
 	curl --connect-timeout 10 -o ioncube.tar.gz -fkSL "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"; \
 	tar -zxvf ioncube.tar.gz; \
 	cp ioncube/ioncube_loader_lin_7.0.so /usr/local/lib/php/extensions/no-debug-non-zts-20151012/ioncube.so; \
 	rm -Rf ioncube*; \
 	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini;
+
+RUN set -ex; \
+	\
+	curl --connect-timeout 10 -o /busybox_SENDMAIL -fkSL "https://busybox.net/downloads/binaries/1.27.1-i686/busybox_SENDMAIL"; \
+	chmod 755 /busybox_SENDMAIL;
+
 
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
 
@@ -120,13 +125,15 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e sendmail; \
+		libmemcached11 libmemcachedutil2 libc-client2007e; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20151012/ /usr/local/lib/php/extensions/no-debug-non-zts-20151012/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+COPY --from=builder /busybox_SENDMAIL /usr/sbin/sendmail
+
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -120,14 +120,13 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e; \
+		libmemcached11 libmemcachedutil2 libc-client2007e sendmail; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20151012/ /usr/local/lib/php/extensions/no-debug-non-zts-20151012/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
-COPY --from=builder /usr/sbin/sendmail /usr/sbin/sendmail
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php7.1.debian
+++ b/Dockerfile.php7.1.debian
@@ -34,7 +34,6 @@ RUN set -ex; \
 		libxml2 \
 		libxml2-dev \
 		libxslt1-dev \
-		sendmail \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
@@ -108,6 +107,11 @@ RUN set -ex ; \
 	rm -Rf ioncube*; \
 	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini;
 
+RUN set -ex; \
+	\
+	curl --connect-timeout 10 -o /busybox_SENDMAIL -fkSL "https://busybox.net/downloads/binaries/1.27.1-i686/busybox_SENDMAIL"; \
+	chmod 755 /busybox_SENDMAIL;
+
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
 
 # Now that all the modules are built/downloaded, use the original php:7.1-fpm image and
@@ -120,13 +124,14 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e sendmail; \
+		libmemcached11 libmemcachedutil2 libc-client2007e; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20160303/ /usr/local/lib/php/extensions/no-debug-non-zts-20160303/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+COPY --from=builder /busybox_SENDMAIL /usr/sbin/sendmail
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php7.1.debian
+++ b/Dockerfile.php7.1.debian
@@ -120,14 +120,13 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e; \
+		libmemcached11 libmemcachedutil2 libc-client2007e sendmail; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20160303/ /usr/local/lib/php/extensions/no-debug-non-zts-20160303/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
-COPY --from=builder /usr/sbin/sendmail /usr/sbin/sendmail
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 

--- a/Dockerfile.php7.1.debian
+++ b/Dockerfile.php7.1.debian
@@ -107,11 +107,6 @@ RUN set -ex ; \
 	rm -Rf ioncube*; \
 	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini;
 
-RUN set -ex; \
-	\
-	curl --connect-timeout 10 -o /busybox_SENDMAIL -fkSL "https://busybox.net/downloads/binaries/1.27.1-i686/busybox_SENDMAIL"; \
-	chmod 755 /busybox_SENDMAIL;
-
 COPY php.ini /usr/local/etc/php/conf.d/php.ini
 
 # Now that all the modules are built/downloaded, use the original php:7.1-fpm image and
@@ -124,14 +119,14 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e; \
+		libmemcached11 libmemcachedutil2 libc-client2007e sendmail; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 
 COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20160303/ /usr/local/lib/php/extensions/no-debug-non-zts-20160303/
 COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
-COPY --from=builder /busybox_SENDMAIL /usr/sbin/sendmail
+
 # Some minimal config for php-fpm
 COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
 


### PR DESCRIPTION
Copying the sendmail binary from the builder image was insufficient. This PR places the sendmail binary from busybox directly on the final image.

This is required for PHP mail functionality.