### PR TITLE
[CMWP-1949] Adding freetype to gd config

### DIFF
--- a/Dockerfile.php5.6.debian
+++ b/Dockerfile.php5.6.debian
@@ -33,6 +33,7 @@ RUN set -ex; \
 		libssl-dev \
 		libtinfo-dev \
 		libtool \
+		libwebp-dev \
 		libxml2 \
 		libxml2-dev \
 		libxpm-dev \
@@ -117,7 +118,7 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev ssmtp; \
+		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev libwebp-dev ssmtp; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;

--- a/Dockerfile.php5.6.debian
+++ b/Dockerfile.php5.6.debian
@@ -39,7 +39,7 @@ RUN set -ex; \
 		libxslt1-dev \
 	; \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
-	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-freetype-dir=/usr; \
 	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-install \
 		bcmath \	

--- a/Dockerfile.php5.6.debian
+++ b/Dockerfile.php5.6.debian
@@ -35,11 +35,17 @@ RUN set -ex; \
 		libtool \
 		libxml2 \
 		libxml2-dev \
+		libxpm-dev \
 		libxslt-dev \
 		libxslt1-dev \
 	; \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
-	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-freetype-dir=/usr; \
+	docker-php-ext-configure gd \
+		--with-png-dir=/usr \
+		--with-jpeg-dir=/usr \
+		--with-freetype-dir=/usr \
+		--with-xpm-dir=/usr \
+		--with-vpx-dir=/usr; \
 	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-install \
 		bcmath \	
@@ -111,7 +117,7 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e ssmtp; \
+		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev ssmtp; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -31,6 +31,7 @@ RUN set -ex; \
 		libssl-dev \
 		libtinfo-dev \
 		libtool \
+		libwebp-dev \
 		libxml2 \
 		libxml2-dev \
 		libxpm-dev \
@@ -42,6 +43,7 @@ RUN set -ex; \
 		--with-png-dir=/usr \
 		--with-jpeg-dir=/usr \
 		--with-freetype-dir=/usr \
+		--with-webp-dir=/usr \
 		--with-xpm-dir=/usr \
 		--with-vpx-dir=/usr; \
 	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
@@ -124,7 +126,7 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev ssmtp; \
+		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev libwebp-dev ssmtp; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -37,7 +37,7 @@ RUN set -ex; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-freetype-dir=/usr; \
 	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
 	docker-php-ext-install \

--- a/Dockerfile.php7.0.debian
+++ b/Dockerfile.php7.0.debian
@@ -33,11 +33,17 @@ RUN set -ex; \
 		libtool \
 		libxml2 \
 		libxml2-dev \
+		libxpm-dev \
 		libxslt1-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-freetype-dir=/usr; \
+	docker-php-ext-configure gd \
+		--with-png-dir=/usr \
+		--with-jpeg-dir=/usr \
+		--with-freetype-dir=/usr \
+		--with-xpm-dir=/usr \
+		--with-vpx-dir=/usr; \
 	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
 	docker-php-ext-install \
@@ -66,7 +72,6 @@ RUN set -ex; \
 		xsl \ 
 		zip \
 	; \
-
 	pecl install \
 		igbinary-2.0.1 \
 		imagick-3.4.3 \
@@ -119,7 +124,7 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e ssmtp; \
+		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev ssmtp; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;

--- a/Dockerfile.php7.1.debian
+++ b/Dockerfile.php7.1.debian
@@ -37,7 +37,7 @@ RUN set -ex; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr; \
+	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-freetype-dir=/usr; \
 	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
 	docker-php-ext-install \

--- a/Dockerfile.php7.1.debian
+++ b/Dockerfile.php7.1.debian
@@ -33,11 +33,17 @@ RUN set -ex; \
 		libtool \
 		libxml2 \
 		libxml2-dev \
+		libxpm-dev \
 		libxslt1-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-freetype-dir=/usr; \
+	docker-php-ext-configure gd \
+		--with-png-dir=/usr \
+		--with-jpeg-dir=/usr \
+		--with-freetype-dir=/usr \
+		--with-xpm-dir=/usr \
+		--with-vpx-dir=/usr; \
 	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
 	docker-php-ext-install \
@@ -66,7 +72,6 @@ RUN set -ex; \
 		xsl \ 
 		zip \
 	; \
-
 	pecl install \
 		igbinary-2.0.1 \
 		imagick-3.4.3 \
@@ -119,7 +124,7 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e ssmtp; \
+		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev ssmtp; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;

--- a/Dockerfile.php7.1.debian
+++ b/Dockerfile.php7.1.debian
@@ -31,6 +31,7 @@ RUN set -ex; \
 		libssl-dev \
 		libtinfo-dev \
 		libtool \
+		libwebp-dev \
 		libxml2 \
 		libxml2-dev \
 		libxpm-dev \
@@ -43,6 +44,7 @@ RUN set -ex; \
 		--with-jpeg-dir=/usr \
 		--with-freetype-dir=/usr \
 		--with-xpm-dir=/usr \
+		--with-webp-dir=/usr \
 		--with-vpx-dir=/usr; \
 	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
 	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
@@ -124,7 +126,7 @@ RUN set -ex ; \
 	\
 	apt-get update && apt-get install -y --no-install-recommends \
         libpng12-0 libicu52 libmcrypt4 libxslt1.1 libmagickwand-6.q16-2 \
-		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev ssmtp; \
+		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev libwebp-dev ssmtp; \
 	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
 	cd /usr/local/etc/php; \
 	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;


### PR DESCRIPTION
gd configure was missing FreeType support. The required freetype libs are already included in the image, so only a configure reference was needed.