### PR TITLE
[CMWP-1205] PHP 7.2 Support

### DIFF
--- a/Dockerfile.php7.2.debian
+++ b/Dockerfile.php7.2.debian
@@ -1,0 +1,127 @@
+FROM php:7.2-fpm as builder
+
+RUN set -ex; \
+	\
+	apt-get update; \
+	apt-get install -y \
+		autoconf \
+		build-essential \
+		libbsd-dev \
+		libbz2-dev \
+		libc-client2007e-dev \
+		libc-dev \
+		libcurl3 \
+		libcurl3-dev \
+		libcurl4-openssl-dev \
+		libedit-dev \
+		libedit2 \
+		libicu-dev \
+		libjpeg-dev \
+		libkrb5-dev \
+		libldap2-dev \
+		libmagick++-dev \
+		libmagickwand-dev \
+		libmemcached-dev \
+		libpcre3-dev \
+		libpng-dev \
+		libsqlite3-0 \
+		libsqlite3-dev \
+		libssh2-1-dev \
+		libssl-dev \
+		libtinfo-dev \
+		libtool \
+		libwebp-dev \
+		libxml2 \
+		libxml2-dev \
+		libxpm-dev \
+		libxslt1-dev \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	docker-php-ext-configure gd \
+		--with-png-dir=/usr \
+		--with-jpeg-dir=/usr \
+		--with-freetype-dir=/usr \
+		--with-xpm-dir=/usr \
+		--with-webp-dir=/usr \
+		--with-vpx-dir=/usr; \
+	docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
+	docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu; \
+	docker-php-ext-install \
+		bcmath \	
+		bz2 \
+		calendar \
+		dba \
+		exif \
+		gd \
+		gettext \
+		imap \
+		intl \
+		ldap \
+		mysqli \
+		opcache \
+		pdo_mysql \
+		shmop \
+		soap \
+		sockets \
+		sysvmsg \
+		sysvsem \
+		sysvshm \
+		wddx \
+		xmlrpc \
+		xsl \ 
+		zip \
+	; \
+	pecl install \
+		igbinary-2.0.1 \
+		imagick-3.4.3 \
+		memcached-3.0.3 \
+		msgpack-2.0.2 \
+		redis-3.1.3 \
+		uopz-5.0.2 \
+	; \
+	echo "\n" | pecl install ssh2-1.1.2; \
+	docker-php-ext-enable --ini-name pecl.ini \
+		igbinary \
+		imagick \
+		memcached \
+		msgpack \
+		redis \
+		ssh2 \
+		uopz \
+	;
+
+RUN set -ex; \
+	\
+	curl --connect-timeout 10 -o ioncube.tar.gz -fkSL "https://www.ioncube.com/php-7.2.0-beta-loaders/ioncube_loaders_lin_x86-64_BETA.tar.gz"; \
+	tar -zxvf ioncube.tar.gz; \
+	cp ioncube_loader_lin_7.2_10.1.0_beta.so /usr/local/lib/php/extensions/no-debug-non-zts-20170718/ioncube.so; \
+	rm -Rf ioncube*; \
+	echo "zend_extension=ioncube.so" > /usr/local/etc/php/conf.d/01-ioncube.ini;
+
+COPY php.ini /usr/local/etc/php/conf.d/php.ini
+
+# Now that all the modules are built/downloaded, use the original php:7.1-fpm image and
+# install only the runtime dependencies with the new modules and config files.
+FROM php:7.2-fpm
+
+WORKDIR /
+
+RUN set -ex ; \
+	\
+	apt-get update && apt-get install -y --no-install-recommends \
+        libpng16-16 libicu57 libmcrypt4 libxslt1.1 libmagickwand-6.q16-3 \
+		libmemcached11 libmemcachedutil2 libc-client2007e libxpm-dev libwebp-dev ssmtp; \
+	rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
+	cd /usr/local/etc/php; \
+	php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
+
+COPY --from=builder /usr/local/lib/php/extensions/no-debug-non-zts-20170718/ /usr/local/lib/php/extensions/no-debug-non-zts-20170718/
+COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+
+# Some minimal config for php-fpm
+COPY www.conf-default /usr/local/etc/php-fpm.d/www.conf
+COPY ssmtp.conf /etc/ssmtp/ssmtp.conf
+
+EXPOSE 9000
+CMD ["php-fpm"]


### PR DESCRIPTION
Adding initial support for PHP 7.2.

No NewRelic agent since it's not supported in 7.2 yet.