### PR TITLE
Add vpx back 

### DIFF
--- a/Dockerfile.php5.6
+++ b/Dockerfile.php5.6
@@ -122,6 +122,7 @@ RUN set -ex ; \
 		libmcrypt4 \
 		libmemcached11 \
 		libmemcachedutil2 \
+		libvpx-dev \
 		libwebp-dev \
 		libxpm-dev \
 		libxslt1.1 \

--- a/Dockerfile.php7.0
+++ b/Dockerfile.php7.0
@@ -129,6 +129,7 @@ RUN set -ex ; \
 		libmcrypt4 \
 		libmemcached11 \
 		libmemcachedutil2 \
+		libvpx-dev \
 		libwebp-dev \
 		libxpm-dev \
 		libxslt1.1 \

--- a/Dockerfile.php7.1
+++ b/Dockerfile.php7.1
@@ -129,6 +129,7 @@ RUN set -ex ; \
 		libmcrypt4 \
 		libmemcached11 \
 		libmemcachedutil2 \
+		libvpx-dev \
 		libwebp-dev \
 		libxpm-dev \
 		libxslt1.1 \

--- a/Dockerfile.php7.2
+++ b/Dockerfile.php7.2
@@ -127,6 +127,7 @@ RUN set -ex ; \
 		libmcrypt4 \
 		libmemcached11 \
 		libmemcachedutil2 \
+		libvpx-dev \
 		libwebp-dev \
 		libxpm-dev \
 		libxslt1.1 \


### PR DESCRIPTION
Accidentally dropped the vpx library from the images.  Adding it back so that gd.so functions properly.