### PR TITLE
stretch package names, gnupg is PECL not core

### DIFF
--- a/Dockerfile.php5.6
+++ b/Dockerfile.php5.6
@@ -15,6 +15,7 @@ RUN set -ex; \
         libedit-dev \
         libedit2 \
         libgmp-dev \
+        libgpgme11-dev \
         libicu-dev \
         libjpeg-dev \
         libkrb5-dev \
@@ -26,10 +27,8 @@ RUN set -ex; \
         libmemcached-dev \
         libpcre3-dev \
         libpng-dev \
-        libpng12-dev \
         libsqlite3-0 \
         libsqlite3-dev \
-        libssh-dev \
         libssh2-1-dev \
         libssl-dev \
         libtinfo-dev \
@@ -39,7 +38,6 @@ RUN set -ex; \
         libxml2 \
         libxml2-dev \
         libxpm-dev \
-        libxslt-dev \
         libxslt1-dev \
     ; \
     apt-get clean; \
@@ -63,7 +61,6 @@ RUN set -ex; \
         gd \
         gettext \
         gmp \
-        gnupg \
         imap \
         intl \
         ldap \
@@ -84,6 +81,7 @@ RUN set -ex; \
         zip \
     ; \
     pecl install \
+        gnupg-1.4.0 \
         igbinary-2.0.1 \
         imagick-3.4.3 \
         memcached-2.2.0 \
@@ -93,6 +91,7 @@ RUN set -ex; \
     ; \
     echo "\n" | pecl install ssh2-0.13; \
     docker-php-ext-enable --ini-name pecl.ini \
+        gnupg \
         igbinary \
         imagick \
         memcached \
@@ -124,17 +123,18 @@ RUN set -ex ; \
     \
     apt-get update && apt-get install -y --no-install-recommends \
         libc-client2007e \
-        libicu52 \
-        libmagickwand-6.q16-2 \
+        libgpgme11 \
+        libicu57 \
+        libmagickwand-6.q16-3 \
         libmcrypt4 \
         libmemcached11 \
         libmemcachedutil2 \
-        libvpx-dev \
-        libwebp-dev \
-        libxpm-dev \
+        libpng16-16 \
+        libvpx4 \
+        libwebp6 \
+        libxpm4 \
         libxslt1.1 \
         ssmtp \
-        libpng12-0 \
         ; \
     rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
     cd /usr/local/etc/php; \

--- a/Dockerfile.php7.0
+++ b/Dockerfile.php7.0
@@ -9,13 +9,13 @@ RUN set -ex; \
         libbsd-dev \
         libbz2-dev \
         libc-client2007e-dev \
-        libc-dev \
+        libc6-dev \
         libcurl3 \
-        libcurl3-dev \
         libcurl4-openssl-dev \
         libedit-dev \
         libedit2 \
         libgmp-dev \
+        libgpgme11-dev \
         libicu-dev \
         libjpeg-dev \
         libkrb5-dev \
@@ -33,6 +33,7 @@ RUN set -ex; \
         libtinfo-dev \
         libtool \
         libwebp-dev \
+        libvpx-dev \
         libxml2 \
         libxml2-dev \
         libxpm-dev \
@@ -59,7 +60,6 @@ RUN set -ex; \
         gd \
         gettext \
         gmp \
-        gnupg \
         imap \
         intl \
         ldap \
@@ -79,6 +79,7 @@ RUN set -ex; \
         zip \
     ; \
     pecl install \
+        gnupg-1.4.0 \
         igbinary-2.0.1 \
         imagick-3.4.3 \
         memcached-3.0.3 \
@@ -88,6 +89,7 @@ RUN set -ex; \
     ; \
     echo "\n" | pecl install ssh2-1.1.2; \
     docker-php-ext-enable --ini-name pecl.ini \
+        gnupg \
         igbinary \
         imagick \
         memcached \
@@ -128,17 +130,18 @@ RUN set -ex ; \
     \
     apt-get update && apt-get install -y --no-install-recommends \
         libc-client2007e \
-        libicu52 \
-        libmagickwand-6.q16-2 \
+        libgpgme11 \
+        libicu57 \
+        libmagickwand-6.q16-3 \
         libmcrypt4 \
         libmemcached11 \
         libmemcachedutil2 \
-        libvpx-dev \
-        libwebp-dev \
-        libxpm-dev \
+        libpng16-16 \
+        libvpx4 \
+        libwebp6 \
+        libxpm4 \
         libxslt1.1 \
         ssmtp \
-        libpng12-0 \
         ; \
     rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
     cd /usr/local/etc/php; \

--- a/Dockerfile.php7.1
+++ b/Dockerfile.php7.1
@@ -9,13 +9,13 @@ RUN set -ex; \
         libbsd-dev \
         libbz2-dev \
         libc-client2007e-dev \
-        libc-dev \
+        libc6-dev \
         libcurl3 \
-        libcurl3-dev \
         libcurl4-openssl-dev \
         libedit-dev \
         libedit2 \
         libgmp-dev \
+        libgpgme11-dev \
         libicu-dev \
         libjpeg-dev \
         libkrb5-dev \
@@ -32,6 +32,7 @@ RUN set -ex; \
         libssl-dev \
         libtinfo-dev \
         libtool \
+        libvpx-dev \
         libwebp-dev \
         libxml2 \
         libxml2-dev \
@@ -59,7 +60,6 @@ RUN set -ex; \
         gd \
         gettext \
         gmp \
-        gnupg \
         imap \
         intl \
         ldap \
@@ -79,6 +79,7 @@ RUN set -ex; \
         zip \
     ; \
     pecl install \
+        gnupg-1.4.0 \
         igbinary-2.0.1 \
         imagick-3.4.3 \
         memcached-3.0.3 \
@@ -88,6 +89,7 @@ RUN set -ex; \
     ; \
     echo "\n" | pecl install ssh2-1.1.2; \
     docker-php-ext-enable --ini-name pecl.ini \
+        gnupg \
         igbinary \
         imagick \
         memcached \
@@ -128,17 +130,18 @@ RUN set -ex ; \
     \
     apt-get update && apt-get install -y --no-install-recommends \
         libc-client2007e \
-        libicu52 \
-        libmagickwand-6.q16-2 \
+        libgpgme11 \
+        libicu57 \
+        libmagickwand-6.q16-3 \
         libmcrypt4 \
         libmemcached11 \
         libmemcachedutil2 \
-        libvpx-dev \
-        libwebp-dev \
-        libxpm-dev \
+        libpng16-16 \
+        libvpx4 \
+        libwebp6 \
+        libxpm4 \
         libxslt1.1 \
         ssmtp \
-        libpng12-0 \
         ; \
     rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
     cd /usr/local/etc/php; \

--- a/Dockerfile.php7.2
+++ b/Dockerfile.php7.2
@@ -9,13 +9,13 @@ RUN set -ex; \
         libbsd-dev \
         libbz2-dev \
         libc-client2007e-dev \
-        libc-dev \
+        libc6-dev \
         libcurl3 \
-        libcurl3-dev \
         libcurl4-openssl-dev \
         libedit-dev \
         libedit2 \
         libgmp-dev \
+        libgpgme11-dev \
         libicu-dev \
         libjpeg-dev \
         libkrb5-dev \
@@ -31,6 +31,7 @@ RUN set -ex; \
         libssl-dev \
         libtinfo-dev \
         libtool \
+        libvpx-dev \
         libwebp-dev \
         libxml2 \
         libxml2-dev \
@@ -58,7 +59,6 @@ RUN set -ex; \
         gd \
         gettext \
         gmp \
-        gnupg \
         imap \
         intl \
         ldap \
@@ -77,6 +77,7 @@ RUN set -ex; \
         zip \
     ; \
     pecl install \
+        gnupg-1.4.0 \
         igbinary-2.0.1 \
         imagick-3.4.3 \
         memcached-3.0.3 \
@@ -86,6 +87,7 @@ RUN set -ex; \
     ; \
     echo "\n" | pecl install ssh2-1.1.2; \
     docker-php-ext-enable --ini-name pecl.ini \
+        gnupg \
         igbinary \
         imagick \
         memcached \
@@ -126,17 +128,18 @@ RUN set -ex ; \
     \
     apt-get update && apt-get install -y --no-install-recommends \
         libc-client2007e \
+        libgpgme11 \
         libicu57 \
         libmagickwand-6.q16-3 \
         libmcrypt4 \
         libmemcached11 \
         libmemcachedutil2 \
-        libvpx-dev \
-        libwebp-dev \
-        libxpm-dev \
+        libpng16-16 \
+        libvpx4 \
+        libwebp6 \
+        libxpm4 \
         libxslt1.1 \
         ssmtp \
-        libpng16-16 \
         ; \
     rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
     cd /usr/local/etc/php; \


### PR DESCRIPTION
upstream php-fpm images are no longer jessie, so we need stretch package names for ICU, PNG, and XSLT libs.

I done goofed in #21:
- docker-php-ext-install is meant for core modules with source bundled
- gnupg extension requires the gpgme library

also killed some snakes while here:
- runtime stage doesn't need vpx/webp/xpm dev packages

runtime libraries remain correctly installed:
```
docker build -t php5.6 -f Dockerfile.php5.6 .
docker run --rm -t php5.6 ldd '/usr/local/lib/php/extensions/no-debug-non-zts-20131226/*.so' | grep 'not found'
```

```
docker build -t php7.0 -f Dockerfile.php7.0 .
docker run --rm -t php7.0 ldd '/usr/local/lib/php/extensions/no-debug-non-zts-20151012/*.so' | grep 'not found'
```

```
docker build -t php7.1 -f Dockerfile.php7.1 .
docker run --rm -t php7.1 ldd '/usr/local/lib/php/extensions/no-debug-non-zts-20160303/*.so' | grep 'not found'
```

```
docker build -t php7.2 -f Dockerfile.php7.2 .
docker run --rm -t php7.1 ldd '/usr/local/lib/php/extensions/no-debug-non-zts-zts-20170718/' | grep 'not found'
```