### PR TITLE
Fix bash syntax

### DIFF
--- a/Dockerfile.php5.6
+++ b/Dockerfile.php5.6
@@ -186,11 +186,11 @@ RUN set -ex \
     } | tee /usr/local/etc/php-fpm.d/www.conf \
     && mkdir -p /usr/local/php/php/auto_prepends \
     && { \
-        echo '<?php' \
-        echo 'if (function_exists("uopz_allow_exit")) {' \
-        echo '    uopz_allow_exit(true);' \
-        echo '}' \
-        echo '?>' \
+        echo '<?php'; \
+        echo 'if (function_exists("uopz_allow_exit")) {'; \
+        echo '    uopz_allow_exit(true);'; \
+        echo '}'; \
+        echo '?>'; \
     } | tee /usr/local/php/php/auto_prepends/default_prepend.php \
     && { \
         echo 'FromLineOverride=YES'; \
@@ -198,11 +198,11 @@ RUN set -ex \
         echo 'UseTLS=NO'; \
         echo 'UseSTARTTLS=NO'; \
     } | tee /etc/ssmtp/ssmtp.conf \
-        && { \
+    && { \
         echo '[PHP]'; \
         echo 'log_errors = On'; \
         echo 'error_log = /dev/stderr'; \
-        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php;' \
+        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php'; \
     } | tee /usr/local/etc/php/conf.d/php.ini \
     ;
 

--- a/Dockerfile.php7.0
+++ b/Dockerfile.php7.0
@@ -193,11 +193,11 @@ RUN set -ex \
     } | tee /usr/local/etc/php-fpm.d/www.conf \
     && mkdir -p /usr/local/php/php/auto_prepends \
     && { \
-        echo '<?php' \
-        echo 'if (function_exists("uopz_allow_exit")) {' \
-        echo '    uopz_allow_exit(true);' \
-        echo '}' \
-        echo '?>' \
+        echo '<?php'; \
+        echo 'if (function_exists("uopz_allow_exit")) {;' \
+        echo '    uopz_allow_exit(true);'; \
+        echo '}'; \
+        echo '?>'; \
     } | tee /usr/local/php/php/auto_prepends/default_prepend.php \
     && { \
         echo 'FromLineOverride=YES'; \
@@ -205,11 +205,11 @@ RUN set -ex \
         echo 'UseTLS=NO'; \
         echo 'UseSTARTTLS=NO'; \
     } | tee /etc/ssmtp/ssmtp.conf \
-        && { \
+    && { \
         echo '[PHP]'; \
         echo 'log_errors = On'; \
         echo 'error_log = /dev/stderr'; \
-        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php;' \
+        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php'; \
     } | tee /usr/local/etc/php/conf.d/php.ini \
     ;
 

--- a/Dockerfile.php7.1
+++ b/Dockerfile.php7.1
@@ -193,11 +193,11 @@ RUN set -ex \
     } | tee /usr/local/etc/php-fpm.d/www.conf \
     && mkdir -p /usr/local/php/php/auto_prepends \
     && { \
-        echo '<?php' \
-        echo 'if (function_exists("uopz_allow_exit")) {' \
-        echo '    uopz_allow_exit(true);' \
-        echo '}' \
-        echo '?>' \
+        echo '<?php'; \
+        echo 'if (function_exists("uopz_allow_exit")) {'; \
+        echo '    uopz_allow_exit(true);'; \
+        echo '}'; \
+        echo '?>'; \
     } | tee /usr/local/php/php/auto_prepends/default_prepend.php \
     && { \
         echo 'FromLineOverride=YES'; \
@@ -205,11 +205,11 @@ RUN set -ex \
         echo 'UseTLS=NO'; \
         echo 'UseSTARTTLS=NO'; \
     } | tee /etc/ssmtp/ssmtp.conf \
-        && { \
+    && { \
         echo '[PHP]'; \
         echo 'log_errors = On'; \
         echo 'error_log = /dev/stderr'; \
-        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php;' \
+        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php'; \
     } | tee /usr/local/etc/php/conf.d/php.ini \
     ;
 

--- a/Dockerfile.php7.2
+++ b/Dockerfile.php7.2
@@ -191,11 +191,11 @@ RUN set -ex \
     } | tee /usr/local/etc/php-fpm.d/www.conf \
     && mkdir -p /usr/local/php/php/auto_prepends \
     && { \
-        echo '<?php' \
-        echo 'if (function_exists("uopz_allow_exit")) {' \
-        echo '    uopz_allow_exit(true);' \
-        echo '}' \
-        echo '?>' \
+        echo '<?php'; \
+        echo 'if (function_exists("uopz_allow_exit")) {'; \
+        echo '    uopz_allow_exit(true);'; \
+        echo '}'; \
+        echo '?>'; \
     } | tee /usr/local/php/php/auto_prepends/default_prepend.php \
     && { \
         echo 'FromLineOverride=YES'; \
@@ -203,11 +203,11 @@ RUN set -ex \
         echo 'UseTLS=NO'; \
         echo 'UseSTARTTLS=NO'; \
     } | tee /etc/ssmtp/ssmtp.conf \
-        && { \
+    && { \
         echo '[PHP]'; \
         echo 'log_errors = On'; \
         echo 'error_log = /dev/stderr'; \
-        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php;' \
+        echo 'auto_prepend_file = /usr/local/php/php/auto_prepends/default_prepend.php'; \
     } | tee /usr/local/etc/php/conf.d/php.ini \
     ;
 


### PR DESCRIPTION
We're missing some `;` in some of the bash and docker hub is complaining.