### PR TITLE
[NOJIRA] Do not kill gcc

### DIFF
--- a/Dockerfile.php5.6
+++ b/Dockerfile.php5.6
@@ -136,7 +136,7 @@ RUN set -ex ; \
         libxslt1.1 \
         ssmtp \
         ; \
-    rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
+    rm -rf /tmp/pear /usr/share/doc /usr/share/man /var/lib/apt/lists/*; \
     cd /usr/local/etc/php; \
     php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 

--- a/Dockerfile.php7.0
+++ b/Dockerfile.php7.0
@@ -143,7 +143,7 @@ RUN set -ex ; \
         libxslt1.1 \
         ssmtp \
         ; \
-    rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
+    rm -rf /tmp/pear /usr/share/doc /usr/share/man /var/lib/apt/lists/*; \
     cd /usr/local/etc/php; \
     php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 

--- a/Dockerfile.php7.1
+++ b/Dockerfile.php7.1
@@ -143,7 +143,7 @@ RUN set -ex ; \
         libxslt1.1 \
         ssmtp \
         ; \
-    rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
+    rm -rf /tmp/pear /usr/share/doc /usr/share/man /var/lib/apt/lists/*; \
     cd /usr/local/etc/php; \
     php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 

--- a/Dockerfile.php7.2
+++ b/Dockerfile.php7.2
@@ -141,7 +141,7 @@ RUN set -ex ; \
         libxslt1.1 \
         ssmtp \
         ; \
-    rm -rf /tmp/pear /usr/share/doc /usr/share/man /usr/lib/gcc /var/lib/apt/lists/*; \
+    rm -rf /tmp/pear /usr/share/doc /usr/share/man /var/lib/apt/lists/*; \
     cd /usr/local/etc/php; \
     php-fpm -v 2>/dev/null | sed -E 's/PHP ([5|7].[0-9]{1,2}.[0-9]{1,2})(.*)/\1/g' | head -n1 > php_version.txt;
 


### PR DESCRIPTION
Killing the /usr/lib/gcc directory (originally done to shave bytes off the final image size) impedes the ability to compile additional modules later.